### PR TITLE
Fix /company command freezing in Cowork

### DIFF
--- a/plugins/sub-company/commands/company.md
+++ b/plugins/sub-company/commands/company.md
@@ -1,6 +1,6 @@
 ---
 description: 専属子会社の設立・ダッシュボード表示・管理
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 argument-hint: [setup | dashboard | rename [名前] | setup-github | 自由入力]
 ---
 


### PR DESCRIPTION
## Summary
- `/company` コマンドの `allowed-tools` に `Agent` が未設定だったため、サブエージェント spawn 時にコマンドがフリーズする問題を修正
- SKILL.md では部署への命令を Agent ツールで実行する設計だが、command 定義側で許可されていなかった

## Test plan
- [ ] Cowork 環境で `/company setup` を実行し、フリーズしないことを確認
- [ ] `/company` で自然言語入力→部署実行が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)