### PR TITLE
Release v0.10.0

### DIFF
--- a/plugins/sub-company/.claude-plugin/plugin.json
+++ b/plugins/sub-company/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sub-company",
-  "version": "0.8.3",
+  "version": "0.10.0",
   "description": "専属子会社を設立してClaudeを活用。秘書が各部署（PM・開発・マーケ・営業・経営企画・品質管理）へ命令を出して仕事を自律実行。サブエージェント並列実行・CEO召喚・GitHub Issues連携に対応。Claude Code用プラグイン。",
   "author": {
     "name": "Pnosuke",

--- a/plugins/sub-company/CHANGELOG.md
+++ b/plugins/sub-company/CHANGELOG.md
@@ -1,5 +1,40 @@
 # CHANGELOG
 
+## [0.10.0] - 2026-04-01
+
+### 追加
+- **agentskills.io 標準対応**: スキル・コマンドのメタデータを agentskills.io 仕様に準拠
+  - SKILL.md / 各コマンドの frontmatter に schema_version, capabilities, inputs, outputs 等を追加
+  - `agentskills.json` スキルパックマニフェストを新規作成
+- **オブザーバビリティ基盤（Phase 1）**: 実行トレーシングログの自動記録
+  - 各Agent実行の開始・完了・所要時間・エラーを `company/logs/YYYY-MM-DD-trace.md` に出力
+  - 日次サマリー（総命令数・成功率・稼働部署）を自動生成
+- **ブラウザ統合**: 品質管理部のQAレビューにブラウザベースの視覚的テストを導入
+  - `browser_backend` 設定で切り替え可能: `claude-in-chrome`（推奨） / `gstack` / `none`
+  - claude-in-chrome: MCPツールで直接ブラウザ操作。外部依存なし
+  - gstack: Persistent Chromium Daemon 経由。要インストール
+  - 未設定時は利用可能なバックエンドを自動判定
+- **共有メモリシステム（3層メモリ）**: CrewAI 型の知識管理を導入
+  - 短期記憶（Session Memory）: 依頼ごとのコンテキスト管理
+  - 長期記憶（Playbook Memory）: 既存プレイブック機能を長期記憶として位置づけ
+  - エンティティ記憶（Entity Memory）: ユーザー・プロジェクト・クライアント等の固有情報
+  - `memory_backend` 設定で切り替え可能: `markdown`（デフォルト） / `engram`
+  - engram: MCP サーバー経由のハイブリッド検索（FTS5 + ベクトル）+ 連想検索 + A-MEM 自動構造化
+  - 未設定時は markdown バックエンドで動作
+- **3ツール間連携パイプライン**: サブカンパニー → 孔明 → タチコマ の E2E 開発自動化
+  - 「開発パイプラインで」等のキーワードでパイプラインモード発動
+  - `.context.md` による統一コンテキストファイルで3ツール間のデータ受け渡し
+  - 各ツールの利用可能性を自動判定し、未インストール時はセットアップを案内
+
+### 変更
+- ask.md にステップ1.5（共有メモリ参照）、ステップ2P（パイプラインモード）、ステップ5.5（実行ログ記録）を追加
+- departments.md の品質管理部セクションにブラウザベースQAの説明を追加
+
+### 修正
+- plugin.json のバージョンを実態に合わせて更新（#14）
+
+---
+
 ## [0.9.0] - 2026-03-27
 
 ### 追加

--- a/plugins/sub-company/agentskills.json
+++ b/plugins/sub-company/agentskills.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0",
   "skill_pack": {
     "name": "sub-company",
-    "version": "0.1.0",
+    "version": "0.10.0",
     "description": "専属子会社プラグイン - 秘書が各部署へ命令を出してビジネスタスクを実行",
     "author": "kuruusuniku",
     "license": "MIT",

--- a/plugins/sub-company/skills/company-build/SKILL.md
+++ b/plugins/sub-company/skills/company-build/SKILL.md
@@ -4,7 +4,7 @@ description: >
   専属子会社としてユーザーの仕事をMarkdownベースで管理・実行するスキル。
   秘書が各部署（PM・開発・マーケ・営業・経営企画・品質管理）へ命令を出す体制。
   マーケ戦略・提案書・技術調査・売上分析・台本・告知文・デザインリサーチなど業務全般に対応。
-version: 0.1.0
+version: 0.10.0
 schema_version: "1.0"
 author: kuruusuniku
 license: MIT


### PR DESCRIPTION
## Summary

- agentskills.io 標準対応（メタデータ・マニフェスト）
- オブザーバビリティ基盤 Phase 1（Markdownトレーシング）
- ブラウザ統合（claude-in-chrome / gstack / none 切替可能）
- 共有メモリシステム（markdown / engram 切替可能）
- 3ツール間パイプライン（サブカンパニー→孔明→タチコマ E2E）
- plugin.json バージョン修正（#14）

## Test plan

- [ ] `/sub-company:ask` で通常の依頼が動作すること
- [ ] `browser_backend: claude-in-chrome` でブラウザQAが動作すること
- [ ] `memory_backend: markdown` で共有メモリが動作すること
- [ ] 「開発パイプラインで」でパイプラインモードが発動すること
- [ ] plugin.json のバージョンが 0.10.0 であること

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)